### PR TITLE
feat: make route prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ php artisan vendor:publish --tag=vantage-config
 - `store_payload` - Whether to store job payloads (for debugging/retry)
 - `redact_keys` - Keys to redact from payloads (password, token, etc.)
 - `retention_days` - How long to keep job history
+- `routes` - Master switch to register dashboard routes
+- `route_prefix` - Base URI segment for all dashboard routes (default: `vantage`)
 - `notify.email` - Email to notify on failures
 - `notify.slack_webhook` - Slack webhook URL for failures
 - `telemetry.enabled` - Enable performance telemetry (memory/CPU)
@@ -289,6 +291,8 @@ VANTAGE_SLACK_WEBHOOK=https://hooks.slack.com/services/...
 
 # Routes (default: true)
 VANTAGE_ROUTES=true
+# Change the base URL path for the dashboard (default: vantage)
+VANTAGE_ROUTE_PREFIX=vantage
 ```
 
 ## Demo

--- a/config/vantage.php
+++ b/config/vantage.php
@@ -99,11 +99,13 @@ return [
     | Web Routes
     |--------------------------------------------------------------------------
     |
-    | Whether to register web routes for viewing job history.
-    | When enabled, routes will be available at /queue-monitor
+    | Configure how the dashboard routes are registered.
+    | - routes: master switch to register routes at all
+    | - route_prefix: base URI segment for all dashboard routes
     |
     */
     'routes' => env('VANTAGE_ROUTES', true),
+    'route_prefix' => env('VANTAGE_ROUTE_PREFIX', 'vantage'),
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,10 @@ use Illuminate\Support\Facades\Route;
 use HoudaSlassi\Vantage\Http\Controllers\QueueMonitorController;
 use HoudaSlassi\Vantage\Http\Middleware\AuthorizeVantage;
 
-Route::prefix('vantage')->name('vantage.')->middleware(['web', AuthorizeVantage::class])->group(function () {
+$prefix = trim(config('vantage.route_prefix', 'vantage'), '/');
+$prefix = $prefix === '' ? 'vantage' : $prefix;
+
+Route::prefix($prefix)->name('vantage.')->middleware(['web', AuthorizeVantage::class])->group(function () {
     Route::get('/', [QueueMonitorController::class, 'index'])->name('dashboard');
     Route::get('/jobs', [QueueMonitorController::class, 'jobs'])->name('jobs');
     Route::get('/jobs/{id}', [QueueMonitorController::class, 'show'])->name('jobs.show');

--- a/tests/CustomRoutePrefixTestCase.php
+++ b/tests/CustomRoutePrefixTestCase.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace HoudaSlassi\Vantage\Tests;
+
+class CustomRoutePrefixTestCase extends TestCase
+{
+    protected string $routePrefix = 'admin/vantage';
+}
+

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,8 @@
 */
 
 use HoudaSlassi\Vantage\Tests\TestCase;
+use HoudaSlassi\Vantage\Tests\CustomRoutePrefixTestCase;
 
 uses(TestCase::class)->in('Feature', 'Unit');
+uses(CustomRoutePrefixTestCase::class)->in('RoutePrefixTest.php');
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,6 +45,7 @@ composer test
   - Retry chain display
   - Tag filtering
   - Failed jobs page
+- **RoutePrefixTest.php**: Verifies custom route prefix configuration serves the dashboard correctly
 
 ## Load Testing
 

--- a/tests/RoutePrefixTest.php
+++ b/tests/RoutePrefixTest.php
@@ -1,0 +1,8 @@
+<?php
+
+it('respects custom route prefix', function () {
+    $this->get('/admin/vantage')
+        ->assertStatus(200)
+        ->assertSee('Dashboard');
+});
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,8 @@ abstract class TestCase extends Orchestra
 {
     use RefreshDatabase;
 
+    protected string $routePrefix = 'vantage';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,6 +39,7 @@ abstract class TestCase extends Orchestra
 
         // Enable routes for testing
         $app['config']->set('vantage.routes', true);
+        $app['config']->set('vantage.route_prefix', $this->routePrefix);
 
         // Provide application key for encryption-dependent features
         $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));


### PR DESCRIPTION
## Summary
- Add `route_prefix` configuration so teams can change the dashboard URI without touching package code.
- Update `routes/web.php` to read the prefix from config (trimmed, defaulting to `vantage`).
- Document the new setting in README and `.env` sample.
- Introduce `CustomRoutePrefixTestCase` + `RoutePrefixTest` to verify custom prefixes; ensure the shared `TestCase` sets the configured prefix for all tests.

## Testing
```bash
composer test
```
