### PR TITLE
Use string helper function instead of facade

### DIFF
--- a/resources/vantage-views/dashboard.blade.php
+++ b/resources/vantage-views/dashboard.blade.php
@@ -296,7 +296,7 @@
                     <div class="flex items-center justify-between border rounded-lg p-3 hover:bg-gray-50">
                         <div class="flex-1 min-w-0">
                             <span class="text-sm font-medium text-gray-900 truncate block" title="{{ $job->job_class }}">
-                                {{ Str::limit(class_basename($job->job_class), 30) }}
+                                {{ str(class_basename($job->job_class))->limit(30) }}
                             </span>
                             <span class="text-xs text-gray-500">{{ number_format($job->count) }} jobs</span>
                         </div>
@@ -332,7 +332,7 @@
                     <div class="flex items-center justify-between border rounded-lg p-3 hover:bg-gray-50">
                         <div class="flex-1 min-w-0">
                             <span class="text-sm font-medium text-gray-900 truncate block" title="{{ $job->job_class }}">
-                                {{ Str::limit(class_basename($job->job_class), 30) }}
+                                {{ str(class_basename($job->job_class))->limit(30) }}
                             </span>
                             <span class="text-xs text-gray-500">{{ number_format($job->count) }} jobs</span>
                         </div>
@@ -371,7 +371,7 @@
                         <div class="border rounded-lg p-3 hover:bg-gray-50">
                             <div class="flex items-center justify-between mb-2">
                                 <span class="text-sm font-medium text-gray-900 truncate" title="{{ $tagData['tag'] }}">
-                                    {{ Str::limit($tagData['tag'], 20) }}
+                                    {{ str($tagData['tag'])->limit(20) }}
                                 </span>
                                 <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
                                     {{ number_format($tagData['total']) }}
@@ -406,7 +406,7 @@
                     @foreach($topFailingJobs as $job)
                         <div class="flex items-center justify-between">
                             <span class="text-sm font-medium text-gray-900 truncate" title="{{ $job->job_class }}">
-                                {{ Str::limit(class_basename($job->job_class), 25) }}
+                                {{ str(class_basename($job->job_class))->limit(25) }}
                             </span>
                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
                                 {{ number_format($job->failure_count) }}
@@ -429,7 +429,7 @@
                     @foreach($topExceptions as $exception)
                         <div class="flex items-center justify-between">
                             <span class="text-sm font-medium text-gray-900 truncate" title="{{ $exception->exception_class }}">
-                                {{ Str::limit(class_basename($exception->exception_class), 25) }}
+                                {{ str(class_basename($exception->exception_class))->limit(25) }}
                             </span>
                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
                                 {{ number_format($exception->count) }}
@@ -452,7 +452,7 @@
                     @foreach($slowestJobs as $job)
                         <div class="flex items-center justify-between">
                             <span class="text-sm font-medium text-gray-900 truncate" title="{{ $job->job_class }}">
-                                {{ Str::limit(class_basename($job->job_class), 25) }}
+                                {{ str(class_basename($job->job_class))->limit(25) }}
                             </span>
                             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
                                 @if($job->avg_duration < 1000)
@@ -538,7 +538,7 @@
                         <tr>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $job->id }}</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900" title="{{ $job->job_class }}">
-                                {{ Str::limit(class_basename($job->job_class), 30) }}
+                                {{ str(class_basename($job->job_class))->limit(30) }}
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                 {{ $job->queue ?? 'default' }}
@@ -548,7 +548,7 @@
                                     <div class="flex flex-wrap gap-1">
                                         @foreach(array_slice($job->job_tags, 0, 3) as $tag)
                                             <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                                                {{ Str::limit($tag, 15) }}
+                                                {{ str($tag)->limit(15) }}
                                             </span>
                                         @endforeach
                                         @if(count($job->job_tags) > 3)

--- a/resources/vantage-views/failed.blade.php
+++ b/resources/vantage-views/failed.blade.php
@@ -28,16 +28,16 @@
                 <tr class="hover:bg-gray-50">
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $job->id }}</td>
                     <td class="px-6 py-4 text-sm font-medium text-gray-900" title="{{ $job->job_class }}">
-                        {{ Str::limit(class_basename($job->job_class), 30) }}
+                        {{ str(class_basename($job->job_class))->limit(30) }}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {{ $job->queue ?? 'default' }}
                     </td>
                     <td class="px-6 py-4 text-sm text-red-600 font-mono text-xs" title="{{ $job->exception_class }}">
-                        {{ Str::limit(class_basename($job->exception_class), 25) }}
+                        {{ str(class_basename($job->exception_class))->limit(25) }}
                     </td>
                     <td class="px-6 py-4 text-sm text-gray-500" title="{{ $job->exception_message }}">
-                        {{ Str::limit($job->exception_message, 50) }}
+                        {{ str($job->exception_message)->limit(50) }}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {{ $job->finished_at ? $job->finished_at->diffForHumans() : '-' }}

--- a/resources/vantage-views/jobs.blade.php
+++ b/resources/vantage-views/jobs.blade.php
@@ -218,7 +218,7 @@ window.addTagToFilter = function(tag) {
                 <tr class="hover:bg-gray-50">
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">#{{ $job->id }}</td>
                     <td class="px-6 py-4 text-sm font-medium text-gray-900" title="{{ $job->job_class }}">
-                        {{ Str::limit(class_basename($job->job_class), 40) }}
+                        {{ str(class_basename($job->job_class))->limit(40) }}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {{ $job->queue ?? 'default' }}


### PR DESCRIPTION
Fix Class "Str" not found in blade views.
Use string helper function instead of facade, to ensure compatibility with all projects that want to use this dependency.