### PR TITLE
Allow child property classes when `unserializing` command data

### DIFF
--- a/config/vantage.php
+++ b/config/vantage.php
@@ -195,6 +195,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Job Restore Unserialize Allow List
+    |--------------------------------------------------------------------------
+    |
+    | Additional classes to allow when restoring serialized jobs. This is
+    | useful when job objects contain nested/child objects in their properties.
+    | The expected job class is always allowed automatically.
+    |
+    */
+    'unserialize' => [
+        'extra_allowed_classes' => [
+            // App\DataTransferObjects\SomeNestedObject::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Excluded Jobs
     |--------------------------------------------------------------------------
     | Job classes listed here will not be recorded by Vantage.

--- a/src/Console/Commands/RetryFailedJob.php
+++ b/src/Console/Commands/RetryFailedJob.php
@@ -3,12 +3,15 @@
 namespace Storvia\Vantage\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Jobs\Job;
 use Illuminate\Support\Str;
 use Storvia\Vantage\Models\VantageJob;
+use Storvia\Vantage\Support\JobRestorer;
 
 class RetryFailedJob extends Command
 {
-    protected $signature = 'vantage:retry {run_id} {--force : Retry even if payload is not available}';
+    protected $signature = 'vantage:retry {run_id}';
 
     protected $description = 'Retry a failed job run by ID using stored payload';
 
@@ -22,7 +25,7 @@ class RetryFailedJob extends Command
             return self::FAILURE;
         }
 
-        $jobClass = $run->job_class;
+        $jobClass = (string) $run->job_class;
 
         if (! class_exists($jobClass)) {
             $this->error("Job class {$jobClass} not found.");
@@ -30,18 +33,18 @@ class RetryFailedJob extends Command
             return self::FAILURE;
         }
 
-        // Try to restore job from payload
-        $job = $this->restoreJobFromPayload($run);
+        if (! is_subclass_of($jobClass, ShouldQueue::class) &&
+            ! is_subclass_of($jobClass, Job::class)) {
+            $this->error("Invalid job class: {$jobClass}");
 
+            return self::FAILURE;
+        }
+
+        $job = app(JobRestorer::class)->restore($run, $jobClass);
         if (! $job) {
-            if (! $this->option('force')) {
-                $this->warn("No payload available for job #{$run->id}. Use --force to retry with empty constructor.");
+            $this->error('Unable to restore job. Payload might be missing or corrupted.');
 
-                return self::FAILURE;
-            }
-
-            $this->warn('Creating job with empty constructor (--force)');
-            $job = new $jobClass;
+            return self::FAILURE;
         }
 
         $job->queueMonitorRetryOf = $run->id;
@@ -61,83 +64,5 @@ class RetryFailedJob extends Command
         }
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Restore job instance from stored payload
-     */
-    protected function restoreJobFromPayload(VantageJob $run): ?object
-    {
-        if (! $run->payload) {
-            return null;
-        }
-
-        try {
-            $payload = json_decode($run->payload, true);
-
-            if (! $payload) {
-                return null;
-            }
-
-            $jobClass = $run->job_class;
-
-            return $this->recreateJobWithReflection($jobClass, $payload);
-        } catch (\Throwable $e) {
-            $this->error('Failed to restore job from payload: '.$e->getMessage());
-
-            return null;
-        }
-    }
-
-    /**
-     * Recreate job using reflection
-     */
-    protected function recreateJobWithReflection(string $jobClass, array $payload): ?object
-    {
-        try {
-            $reflection = new \ReflectionClass($jobClass);
-            $constructor = $reflection->getConstructor();
-
-            if (! $constructor) {
-                return new $jobClass;
-            }
-
-            $params = $constructor->getParameters();
-            $args = [];
-
-            foreach ($params as $param) {
-                $paramName = $param->getName();
-
-                if (isset($payload[$paramName])) {
-                    $args[] = $this->unserializeValue($payload[$paramName]);
-                } elseif ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
-                } else {
-                    $args[] = null;
-                }
-            }
-
-            return $reflection->newInstanceArgs($args);
-        } catch (\Throwable $e) {
-            $this->error('Failed to recreate job with reflection: '.$e->getMessage());
-
-            return null;
-        }
-    }
-
-    /**
-     * Convert payload value back to original type
-     */
-    protected function unserializeValue($value)
-    {
-        if (is_array($value) && isset($value['model']) && isset($value['id'])) {
-            // Restore Eloquent model
-            $modelClass = $value['model'];
-            if (class_exists($modelClass)) {
-                return $modelClass::find($value['id']);
-            }
-        }
-
-        return $value;
     }
 }

--- a/src/Support/JobRestorer.php
+++ b/src/Support/JobRestorer.php
@@ -51,8 +51,13 @@ class JobRestorer
                 return null;
             }
 
-            $command = @unserialize($serialized, ['allowed_classes' => [$expectedJobClass]]);
+            $extraAllowedClasses = config('vantage.unserialize.extra_allowed_classes', []);
+            $allowedClasses = [
+                $expectedJobClass,
+                ...$extraAllowedClasses,
+            ];
 
+            $command = @unserialize($serialized, ['allowed_classes' => $allowedClasses]);
             if (! is_object($command)) {
                 VantageLogger::warning('Vantage: Unserialize did not return an object', [
                     'job_id' => $job->id,

--- a/tests/Feature/UnserializeSecurityTest.php
+++ b/tests/Feature/UnserializeSecurityTest.php
@@ -45,6 +45,11 @@ class NotAJobClass
     public $data;
 }
 
+class NestedAllowedClass
+{
+    public function __construct(public string $value) {}
+}
+
 it('prevents unserializing malicious classes in Vantage::retryJob', function () {
     $vantage = new Vantage;
 
@@ -228,6 +233,34 @@ it('allows restoring valid job in JobRestorer::restore', function () {
     expect($result)->not->toBeNull()
         ->and($result)->toBeInstanceOf(TestSecureJob::class)
         ->and($result->testProperty)->toBe('test-value');
+});
+
+it('allows restoring job with configured nested class in JobRestorer::restore', function () {
+    config()->set('vantage.unserialize.extra_allowed_classes', [NestedAllowedClass::class]);
+
+    $restorer = new JobRestorer;
+    $testJob = new TestSecureJob(new NestedAllowedClass('nested-value'));
+
+    $job = VantageJob::create([
+        'uuid' => Str::uuid(),
+        'job_class' => TestSecureJob::class,
+        'status' => 'failed',
+        'queue' => 'default',
+        'payload' => json_encode([
+            'raw_payload' => [
+                'data' => [
+                    'command' => serialize($testJob),
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = $restorer->restore($job, TestSecureJob::class);
+
+    expect($result)->not->toBeNull()
+        ->and($result)->toBeInstanceOf(TestSecureJob::class)
+        ->and($result->testProperty)->toBeInstanceOf(NestedAllowedClass::class)
+        ->and($result->testProperty->value)->toBe('nested-value');
 });
 
 it('handles old payload format in Vantage::retryJob', function () {


### PR DESCRIPTION
Also updates the CLI retry command to use the `JobRestorer` like the controllers. 